### PR TITLE
zip 사용하여 livedata 2개 묶음

### DIFF
--- a/TDDToySample/app/src/main/java/com/duzi/tddtoysample/ui/single/SingleModeViewModel.kt
+++ b/TDDToySample/app/src/main/java/com/duzi/tddtoysample/ui/single/SingleModeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.*
 import com.duzi.tddtoysample.domain.usecase.GenerateQuizUseCase
 import com.duzi.tddtoysample.result.process
 import kotlinx.coroutines.launch
+import java.lang.Exception
 
 class SingleModeViewModel(
     private val generateQuizUseCase: GenerateQuizUseCase
@@ -24,11 +25,7 @@ class SingleModeViewModel(
     private val _guess = MutableLiveData<Int>()
 
     // 퀴즈 상태
-    private val _quizState = Transformations.switchMap(_guess) { guess ->
-        _answer.value?.let { answer ->
-            MutableLiveData(checkState(answer, guess))
-        }
-    }
+    private val _quizState = quizStateZipLiveData(_answer, _guess)
     val quizState: LiveData<QuizState> = _quizState
     private var tries: Int = 0
 
@@ -55,6 +52,31 @@ class SingleModeViewModel(
             guess < answer -> QuizState.DOWN
             else -> {
                 QuizState.BINGO(tries)
+            }
+        }
+    }
+
+    // https://medium.com/@gauravgyal/combine-results-from-multiple-async-requests-90b6b45978f7
+    private fun quizStateZipLiveData(answer: LiveData<Int>, guess: LiveData<Int>): LiveData<QuizState> {
+        return MediatorLiveData<QuizState>().apply {
+            var lastAnswer: Int? = null
+            var lastGuess: Int? = null
+
+            fun update() {
+                val localLastAnswer = lastAnswer
+                val localLastGuess = lastGuess
+                if (localLastAnswer != null && localLastGuess != null) {
+                    this.value = checkState(localLastAnswer, localLastGuess)
+                }
+            }
+
+            addSource(answer) {
+                lastAnswer = it
+                update()
+            }
+            addSource(guess) {
+                lastGuess = it
+                update()
             }
         }
     }


### PR DESCRIPTION
## 무엇을
- 비동기로 받아온 answer와 사용자가 입력한 guess의 livedata를 묶음

## 왜
- guess를 입력했을 때 answer에 데이터가 없는 경우가 있음

## 어떻게
- MediatorLiveData를 이용하여 zip livedata 만들어서 두개의 livedata를 한곳에서 처리
